### PR TITLE
GitBook 을 제대로 사용할 수 없는 이슈를 수정해 새 GitBook 링크를 제공하도록 README 를 수정합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
----
-description: Clean Code 스터디의 결과물을 정리합니다.
----
-
-# Introduction
-
 ## Clean Code
 
-Clean Code 스터디의 결과물 정리를 위해 만든 저장소입니다. 다음 gitbook 링크에서 편하게 살펴보실 수 있습니다. [https://kwosu87.gitbooks.io/clean-code/content/](https://kwosu87.gitbooks.io/clean-code/content/)
+Clean Code 스터디의 결과물을 정리하기 위해 만든 저장소입니다. 다음 gitbook 링크에서 편하게 살펴보실 수 있습니다.[https://app.gitbook.com/@innocarpe/s/clean-code](https://app.gitbook.com/@innocarpe/s/clean-code)
+
+하단의 목차는 이 레포 내의 탐색을 위해 제공되고 있습니다. 
 
 ## 목차
 


### PR DESCRIPTION
## 배경

- https://github.com/Yooii-Studios/Clean-Code/issues/19
- 기존 존재하던 GitBook 링크를 눌러봤더니 제대로 동작하질 않네요.

## 작업 내용

- https://www.gitbook.com 에 접속해서 로그인 후 새 `Clean Code` GitBook 을 파서 연동을 새로 했습니다.
- 이미 master 에 커밋되긴 했는데 마크다운 상으로 깨지는 오류들을 수정했어요. 아마 GitHub 마크다운 문법이 바뀌면서 현재 깨지게 된 건가 싶기도 하네요.
- README 파일에 링크를 변경하고, 위 이슈에 있는 궁금증을 미리 해소하기 위해 문구를 조금 변경했습니다.